### PR TITLE
Markdown formatting

### DIFF
--- a/docs/_docs/documentation.md
+++ b/docs/_docs/documentation.md
@@ -3,13 +3,11 @@ title: Documentation
 ---
 
 # {{ page.title }}
-
 {: .no_toc }
 
 {: .fs-6 .fw-300 }
 
 ## Table of contents
-
 {: .no_toc .text-delta }
 
 1. TOC

--- a/docs/_docs/documentation.md
+++ b/docs/_docs/documentation.md
@@ -1,12 +1,15 @@
 ---
 title: Documentation
 ---
+
 # {{ page.title }}
+
 {: .no_toc }
 
 {: .fs-6 .fw-300 }
 
 ## Table of contents
+
 {: .no_toc .text-delta }
 
 1. TOC

--- a/docs/_docs/examples.md
+++ b/docs/_docs/examples.md
@@ -3,13 +3,11 @@ title: "Examples"
 ---
 
 # Examples
-
 {: .no_toc }
 
 {: .fs-6 .fw-300 }
 
 ## Table of contents
-
 {: .no_toc .text-delta }
 
 1. TOC

--- a/docs/_docs/examples.md
+++ b/docs/_docs/examples.md
@@ -1,12 +1,15 @@
 ---
 title: "Examples"
 ---
+
 # Examples
+
 {: .no_toc }
 
 {: .fs-6 .fw-300 }
 
 ## Table of contents
+
 {: .no_toc .text-delta }
 
 1. TOC
@@ -31,23 +34,23 @@ The [NervousText.js](https://github.com/mozilla/rhino/tree/master/examples/Nervo
 
 ## Controlling the JavaScript Engine
 
-#### The RunScript class
+### The RunScript class
 
 [RunScript.java](https://github.com/mozilla/rhino/tree/master/examples/RunScript.java) is a simple program that executes a script from the command line.
 
-#### The Control class
+### The Control class
 
 [Control.java](https://github.com/mozilla/rhino/tree/master/examples/Control.java) is a program that executes a simple script and then manipulates the result.
 
-#### JavaScript Shell
+### JavaScript Shell
 
 [Shell.java](https://github.com/mozilla/rhino/tree/master/examples/Shell.java) is a program that executes JavaScript programs; it is a simplified version of the shell in the `tools` package. The programs may be specified as files on the command line or by typing interactively while the shell is running.
 
-#### PrimitiveWrapFactory
+### PrimitiveWrapFactory
 
 [PrimitiveWrapFactory.java](https://github.com/mozilla/rhino/tree/master/examples/PrimitiveWrapFactory.java) is an example of a WrapFactory that can be used to control the wrapping behavior of the Rhino engine on calls to Java methods.
 
-#### Multithreaded Script Execution
+### Multithreaded Script Execution
 
 [DynamicScopes.java](https://github.com/mozilla/rhino/tree/master/examples/DynamicScopes.java) is a program that creates a single global scope object and then shares it across multiple threads. Sharing the global scope allows both information to be shared across threads, and amortizes the cost of Context.initStandardObjects by only performing that expensive operation once.
 
@@ -55,14 +58,14 @@ The [NervousText.js](https://github.com/mozilla/rhino/tree/master/examples/Nervo
 
 First check out the [tutorial](../_tutorials/embedding_tutorial.md) if you haven't already.
 
-#### The Foo class - Extending ScriptableObject
+### The Foo class - Extending ScriptableObject
 
 [Foo.java](https://github.com/mozilla/rhino/tree/master/examples/Foo.java) is a simple JavaScript host object that includes a property with an associated action and a variable argument method.
 
-#### The Matrix class - Implementing Scriptable
+### The Matrix class - Implementing Scriptable
 
 [Matrix.java](https://github.com/mozilla/rhino/tree/master/examples/Matrix.java) provides a simple multidimensional array by implementing the Scriptable interface.
 
-#### The File class - An advanced example
+### The File class - An advanced example
 
 [File.java](https://github.com/mozilla/rhino/tree/master/examples/File.java) extends ScriptableObject to provide a means of reading and writing files from JavaScript. A more involved example of host object definition.

--- a/docs/_docs/faq.md
+++ b/docs/_docs/faq.md
@@ -2,13 +2,11 @@
 title: "FAQ"
 ---
 # FAQ
-
 {: .no_toc }
 
 {: .fs-6 .fw-300 }
 
 ## Table of contents
-
 {: .no_toc .text-delta }
 
 1. TOC

--- a/docs/_docs/faq.md
+++ b/docs/_docs/faq.md
@@ -2,30 +2,31 @@
 title: "FAQ"
 ---
 # FAQ
+
 {: .no_toc }
 
 {: .fs-6 .fw-300 }
 
 ## Table of contents
+
 {: .no_toc .text-delta }
 
 1. TOC
 {:toc}
 
 ---
-#### Frequently Asked Questions about Rhino
 
 ## How do I create a Java array from JavaScript?
 
 You must use Java reflection. For instance, to create an array of java.lang.String of length five, do
 
-```
+```js
 var stringArray = java.lang.reflect.Array.newInstance(java.lang.String, 5);
 ```
 
 Then if you wish to assign the string "hi" to the first element, simply execute `stringArray[0] = "hi"`. Creating arrays of primitive types is slightly different: you must use the TYPE field. For example, creating an array of seven ints can be done with the code
 
-```
+```js
 var intArray = java.lang.reflect.Array.newInstance(java.lang.Integer.TYPE, 7);
 ```
 

--- a/docs/_docs/footprint.md
+++ b/docs/_docs/footprint.md
@@ -2,13 +2,11 @@
 title: "Small Footprint"
 ---
 # Small Footprint
-
 {: .no_toc }
 
 {: .fs-6 .fw-300 }
 
 ## Table of contents
-
 {: .no_toc .text-delta }
 
 1. TOC

--- a/docs/_docs/footprint.md
+++ b/docs/_docs/footprint.md
@@ -2,11 +2,13 @@
 title: "Small Footprint"
 ---
 # Small Footprint
+
 {: .no_toc }
 
 {: .fs-6 .fw-300 }
 
 ## Table of contents
+
 {: .no_toc .text-delta }
 
 1. TOC
@@ -67,7 +69,7 @@ Class generation library, Regular Expressions, E4X implementataion and
 deprecated files. To build such minimalist jar without debug information,
 run the following command from the top directory of Rhino distribution:
 
-```
+```sh
 ant clean
 ant -Ddebug=off -Dno-regexp=true -Dno-e4x=true smalljar
 ```

--- a/docs/_docs/optimization.md
+++ b/docs/_docs/optimization.md
@@ -1,19 +1,23 @@
 ---
 title: "Optimization Levels"
 ---
+
 # {{ page.title }}
+
 {: .no_toc }
 
 {: .fs-6 .fw-300 }
 
 ## Table of contents
+
 {: .no_toc .text-delta }
 
 1. TOC
 {:toc}
 
 ---
-### Optimization levels
+
+## Optimization levels
 
 The currently supported optimization settings are:
 
@@ -22,6 +26,7 @@ The currently supported optimization settings are:
 |  1-9  |  All optimizations are performed. Simple data and type flow analysis is performed to determine which JavaScript variables can be allocated to Java VM registers, and which variables are used only as Numbers. Local common sub-expressions are collapsed (currently this only happens for property lookup, but in the future more expressions may be optimized). All local variables and parameters are allocated to Java VM registers. Function call targets are speculatively pre-cached (based on the name used in the source) so that dispatching can be direct, pending runtime confirmation of the actual target. Arguments are passed as Object/Number pairs to reduce conversion overhead  |
 
 _Notes:_
+
 - Some language features (indirect calls to eval, use of the arguments property of function objects) were previously not supported in higher optimization levels. These features have been removed from the language in ECMA, so higher optimization levels are now conformant.
 - Future versions may allocate more aggressive optimizations to higher optimization levels. For compatibility with future versions, use level 1. For maximal optimization, use level 9, but retest your application when upgrading to new versions.
 - Scripts are optimized at compile time, not at execution time. So if a Script is compiled with the context's optimizationLevel set to 1, it will be executed with those optimizations, regardless of the optimizationLevel of the context in which it is executed.

--- a/docs/_docs/optimization.md
+++ b/docs/_docs/optimization.md
@@ -3,13 +3,11 @@ title: "Optimization Levels"
 ---
 
 # {{ page.title }}
-
 {: .no_toc }
 
 {: .fs-6 .fw-300 }
 
 ## Table of contents
-
 {: .no_toc .text-delta }
 
 1. TOC

--- a/docs/_docs/overview.md
+++ b/docs/_docs/overview.md
@@ -2,13 +2,11 @@
 title: Overview
 ---
 # {{ page.title }}
-
 {: .no_toc }
 
 {: .fs-6 .fw-300 }
 
 ## Table of contents
-
 {: .no_toc .text-delta }
 
 1. TOC

--- a/docs/_docs/overview.md
+++ b/docs/_docs/overview.md
@@ -2,18 +2,21 @@
 title: Overview
 ---
 # {{ page.title }}
+
 {: .no_toc }
 
 {: .fs-6 .fw-300 }
 
 ## Table of contents
+
 {: .no_toc .text-delta }
 
 1. TOC
 {:toc}
 
 ---
-### Introduction
+
+## Introduction
 
 Most people who have used [JavaScript](https://developer.mozilla.org/en-US/docs/Web/JavaScript) before have done so by adding scripts to their [HTML](https://developer.mozilla.org/en-US/docs/Glossary/HTML) web pages. However, Rhino is an implementation of the core language only and doesn't contain objects or methods for manipulating HTML documents.
 
@@ -25,7 +28,7 @@ Rhino contains
 - [A JavaScript compiler](../_tools/javascript_compiler.md) to transform JavaScript source files into Java class files
 - [A JavaScript debugger](../_tools/debugger.md) for scripts executed with Rhino
 
-### Language
+## Language
 
 The JavaScript language itself is standardized by [Standard ECMA-262 ECMAScript: A general purpose, cross-platform programming language](https://www.ecma-international.org/publications/standards/Ecma-262.htm). Rhino 1.3 and greater conform to Edition 3 of the Standard.
 
@@ -35,15 +38,15 @@ In addition, Rhino has implemented JavaAdapters, which allows JavaScript to impl
 
 Numerous books and tutorials on JavaScript are available. [JavaScript: The Definitive Guide](https://www.oreilly.com/catalog/jscript5/) is recommended, and contains a chapter on Rhino.
 
-### Internationalization
+## Internationalization
 
 The messages reported by the JavaScript engine are by default retrieved from the property file `org/mozilla/javascript/resources/Messages.properties`. If other properties files with extensions corresponding to the current locale exist, they will be used instead.
 
-### JavaScript Language Versions
+## JavaScript Language Versions
 
 Some behavior in the JavaScript engine is dependent on the language version. In browser embeddings, this language version is selected using the `LANGUAGE` attribute of the `SCRIPT` tag with values such as `"JavaScript1.2"`.
 
-### Security
+## Security
 
 The security features in Rhino provide the ability to track the origin of a piece of code (and any pieces of code that it may in turn generate). These features allow for the implementation of a traditional URL-based security policy for JavaScript as in Netscape Navigator. Embeddings that trust the JavaScript code they execute may ignore the security features.
 

--- a/docs/_docs/requirements_and_limitations.md
+++ b/docs/_docs/requirements_and_limitations.md
@@ -3,13 +3,11 @@ title: "Requirements and limitations"
 ---
 
 # Requirements and limitations
-
 {: .no_toc }
 
 {: .fs-6 .fw-300 }
 
 ## Table of contents
-
 {: .no_toc .text-delta }
 
 1. TOC

--- a/docs/_docs/requirements_and_limitations.md
+++ b/docs/_docs/requirements_and_limitations.md
@@ -1,18 +1,22 @@
 ---
 title: "Requirements and limitations"
 ---
+
 # Requirements and limitations
+
 {: .no_toc }
 
 {: .fs-6 .fw-300 }
 
 ## Table of contents
+
 {: .no_toc .text-delta }
 
 1. TOC
 {:toc}
 
 ---
+
 ## Requirements
 
 Recent versions of Rhino have only been tested with JDK 1.4 and greater. Older versions support JDKs as early as 1.1.
@@ -25,7 +29,7 @@ To use the JavaAdapter feature or an optimization level of 0 or greater, Rhino m
 
 If a JavaObject's field's name collides with that of a method, the value of that field is retrieved lazily, and can be counter-intuitively affected by later assignments:
 
-```
+```js
 javaObj.fieldAndMethod = 5;
 var field = javaObj.fieldAndMethod;
 javaObj.fieldAndMethod = 7;
@@ -34,7 +38,7 @@ javaObj.fieldAndMethod = 7;
 
 You can work around this by forcing the field value to be converted to a JavaScript type when you take its value:
 
-```
+```js
 javaObj.fieldAndMethod = 5;
 var field = javaObj.fieldAndMethod + 0; // force conversion now
 javaObj.fieldAndMethod = 7;

--- a/docs/_docs/runtime.md
+++ b/docs/_docs/runtime.md
@@ -3,13 +3,11 @@ title: "JavaScript Runtime"
 ---
 
 # {{ page.title }}
-
 {: .no_toc }
 
 {: .fs-6 .fw-300 }
 
 ## Table of contents
-
 {: .no_toc .text-delta }
 
 1. TOC

--- a/docs/_docs/runtime.md
+++ b/docs/_docs/runtime.md
@@ -1,18 +1,22 @@
 ---
 title: "JavaScript Runtime"
 ---
+
 # {{ page.title }}
+
 {: .no_toc }
 
 {: .fs-6 .fw-300 }
 
 ## Table of contents
+
 {: .no_toc .text-delta }
 
 1. TOC
 {:toc}
 
 ---
+
 ## Interpretation
 
 Beginning with Rhino 1.4 Release 2, an interpretive mode is supported. When scripts are compiled in interpretive mode, an internal representation of the compiled form is created and stored rather than generating a Java class. Execution proceeds by evaluating this compiled form using support routines in Rhino.
@@ -52,7 +56,7 @@ Instead, every property accessor method in [Scriptable](https://mozilla.github.i
 
 Host objects are JavaScript objects that provide special access to the host environment. For example, in a browser environment, the Window and Document objects are host objects.
 
-The easiest way to define new host objects is by using [ScriptableObject.defineClass()](https://p-bakker.github.io/rhino/javadoc/org/mozilla/javascript/ScriptableObject.html#defineClass-org.mozilla.javascript.Scriptable-java.lang.Class-boolean-). This method defines a set of JavaScript objects using a Java class. Several of the (examples)[examples.md] define host objects this way.
+The easiest way to define new host objects is by using [ScriptableObject.defineClass()](https://p-bakker.github.io/rhino/javadoc/org/mozilla/javascript/ScriptableObject.html#defineClass-org.mozilla.javascript.Scriptable-java.lang.Class-boolean-). This method defines a set of JavaScript objects using a Java class. Several of the [examples](examples.md) define host objects this way.
 
 If the services provided by `defineClass` are insufficient, try other methods of [ScriptableObject](https://mozilla.github.io/rhino/javadoc/org/mozilla/javascript/ScriptableObject.html) and [FunctionObject](https://mozilla.github.io/rhino/javadoc/org/mozilla/javascript/FunctionObject.html), such as `defineProperty` and `defineFunctionProperties`.
 

--- a/docs/_docs/scopes_and_contexts.md
+++ b/docs/_docs/scopes_and_contexts.md
@@ -3,13 +3,11 @@ title: "Scopes and contexts"
 ---
 
 # Scopes and contexts
-
 {: .no_toc }
 
 {: .fs-6 .fw-300 }
 
 ## Table of contents
-
 {: .no_toc .text-delta }
 
 1. TOC

--- a/docs/_docs/scopes_and_contexts.md
+++ b/docs/_docs/scopes_and_contexts.md
@@ -1,12 +1,15 @@
 ---
 title: "Scopes and contexts"
 ---
+
 # Scopes and contexts
+
 {: .no_toc }
 
 {: .fs-6 .fw-300 }
 
 ## Table of contents
+
 {: .no_toc .text-delta }
 
 1. TOC
@@ -21,13 +24,13 @@ The Rhino Context object is used to store thread-specific information about the 
 
 To associate the current thread with a Context, simply call the `enter` method of Context:
 
-```
+```java
 Context cx = Context.enter();
 ```
 
 Once you are done with execution, simply exit the Context:
 
-```
+```java
 Context.exit();
 ```
 
@@ -43,7 +46,7 @@ It's important to understand that a scope is independent of the Context that cre
 
 A top-level scope is created by calling `Context.initStandardObjects` to create all the standard objects:
 
-```
+```java
 ScriptableObject scope = cx.initStandardObjects();
 ```
 
@@ -58,7 +61,7 @@ So how are scopes used to look up names? In general, variables are looked up by 
 
 For a more concrete example, let's consider the following script:
 
-```
+```js
 var g = 7;
 
 function f(a) {
@@ -84,7 +87,7 @@ To do this we set an object's prototype. When accessing a property of an object 
 
 So to share information across multiple scopes, we first create the object we wish to share. Typically this object will have been created with `initStandardObjects` and may also have additional objects specific to the embedding. Then all we need to do is create a new object and call its `setPrototype`method to set the prototype to the shared object, and the parent of the new scope to null:
 
-```
+```java
 Scriptable newScope = cx.newObject(sharedScope);
 newScope.setPrototype(sharedScope);
 newScope.setParentScope(null);
@@ -100,13 +103,13 @@ The ECMAScript standard defines that scripts can add properties to all standard 
 
 A notion of a sealed object is a JavaScript extension supported by Rhino and it means that properties can not be added/deleted to the object and the existing object properties can not be changed. Any attempt to modify sealed object throws an exception. To seal all objects in the standard library pass`true` for the sealed argument when calling `Context.initStandardObjects(ScriptableObject, boolean)`:
 
-```
+```java
 ScriptableObject sealedSharedScope = cx.initStandardObjects(null, true);
 ```
 
 This seals only all standard library objects, it does not seal the shared scope itself thus after calling`initStandardObjects`, `sealedSharedScope` can be farther populated with application-specific objects and functions. Then after a custom initialization is done, one can seal the shared scope by calling`ScriptableObject.sealObject()`:
 
-```
+```java
 sealedSharedScope.sealObject();
 ```
 
@@ -114,7 +117,7 @@ Note that currently one needs to explicitly seal any additional properties he ad
 
 Note that currently in order to use Java classes (LiveConnect) from a sealed shared scope you need to pre-load a number of objects needed for LiveConnect into the scope before it gets sealed. These objects would normally be lazy loaded but the lazy loading fails if the scope is sealed.
 
-```
+```java
 ScriptableObject sealedSharedScope  = cx.initStandardObjects(null, true);
 
 // Force the LiveConnect stuff to be loaded.
@@ -135,7 +138,7 @@ The [DynamicScopes example](https://github.com/mozilla/rhino/examples/DynamicSco
 
 The key things to determine in setting up scopes for your application are
 
-1.  What scope should global variables be created in when your script executes an assignment to an undefined variable, and
-3.  What variables should your script have access to when it references a variable?
+1. What scope should global variables be created in when your script executes an assignment to an undefined variable, and
+2. What variables should your script have access to when it references a variable?
 
 The answer to 1 determines which scope should be the ultimate parent scope: Rhino follows the parent chain up to the top and places the variable there. After you've constructed your parent scope chain, the answer to question 2 may indicate that there are additional scopes that need to be searched that are not in your parent scope chain. You can add these as prototypes of scopes in your parent scope chain. When Rhino looks up a variable, it starts in the current scope, walks the prototype chain, then goes to the parent scope and its prototype chain, until there are no more parent scopes left.

--- a/docs/_docs/serialization.md
+++ b/docs/_docs/serialization.md
@@ -3,13 +3,11 @@ title: "Serialization"
 ---
 
 # Serialization
-
 {: .no_toc }
 
 {: .fs-6 .fw-300 }
 
 ## Table of contents
-
 {: .no_toc .text-delta }
 
 1. TOC

--- a/docs/_docs/serialization.md
+++ b/docs/_docs/serialization.md
@@ -1,12 +1,15 @@
 ---
 title: "Serialization"
 ---
+
 # Serialization
+
 {: .no_toc }
 
 {: .fs-6 .fw-300 }
 
 ## Table of contents
+
 {: .no_toc .text-delta }
 
 1. TOC
@@ -19,10 +22,19 @@ Beginning with Rhino 1.5 Release 3 it is possible to serialize JavaScript object
 
 The Rhino shell has two new top-level functions, serialize and deserialize. They're intended mainly as examples of the use of serialization:
 
-```
-`$``java org.mozilla.javascript.tools.shell.Main``js>``function f() { return 3; }``js>``serialize(f, "f.ser")``js>``quit()``$``java org.mozilla.javascript.tools.shell.Main``js>``f = deserialize("f.ser")``function f() {
+```sh
+$ java org.mozilla.javascript.tools.shell.Main
+js> function f() { return 3; }
+js> serialize(f, "f.ser")
+js> quit()
+
+$ java org.mozilla.javascript.tools.shell.Main
+js> f = deserialize("f.ser")
+function f() {
     return 3;
-}``js>``f()``3``js>`
+}
+js> f()
+3
 ```
 
 Here we see a simple case of a function being serialized to a file and then read into a new instance of Rhino and called.
@@ -31,16 +43,22 @@ Here we see a simple case of a function being serialized to a file and then read
 
 Two new classes, `ScriptableOutputStream` and `ScriptableInputStream`, were introduced to handle serialization of Rhino classes. These classes extend `ObjectOutputStream` and `ObjectInputStream` respectively. Writing an object to a file can be done in a few lines of Java code:
 
-```
-`FileOutputStream fos = new FileOutputStream(filename);``ScriptableOutputStream out = new ScriptableOutputStream(fos, scope);``out.writeObject(obj);``out.close();`
+```java
+FileOutputStream fos = new FileOutputStream(filename);
+ScriptableOutputStream out = new ScriptableOutputStream(fos, scope);
+out.writeObject(obj)
+out.close();
 ```
 
 Here _filename_ is the file to write to, _obj_ is the object or function to write, and _scope_ is the top-level scope containing _obj_.
 
 Reading the serialized object back into memory is similarly simple:
 
-```
-`FileInputStream fis = new FileInputStream(filename);``ObjectInputStream in = new ScriptableInputStream(fis, scope);``Object deserialized = in.readObject();``in.close();`
+```java
+FileInputStream fis = new FileInputStream(filename);
+ObjectInputStream in = new ScriptableInputStream(fis, scope);
+Object deserialized = in.readObject();
+in.close();
 ```
 
 Again, we need the scope to create our serialization stream class.
@@ -57,8 +75,9 @@ However, for JavaScript this creates a problem. JavaScript objects contain refer
 
 If you are using Rhino serialization in an environment where you always define, say, a constructor _Foo_, you should add the following code before calling `writeObject`:
 
-```
-`out.addExcludedName("Foo");``out.addExcludedName("Foo.prototype");`
+```java
+out.addExcludedName("Foo");
+out.addExcludedName("Foo.prototype");
 ```
 
 This code will prevent `Foo` and `Foo.prototype` from being serialized and will cause references to `Foo` or `Foo.prototype` to be resolved to the objects in the new scope upon deserialization. Exceptions will be thrown if `Foo` or `Foo.prototype` cannot be found the scopes used in either `ScriptableOutputStream` or `ScriptableInputStream`.
@@ -67,25 +86,36 @@ This code will prevent `Foo` and `Foo.prototype` from being serialized and will 
 
 Serialization works well with objects and with functions and scripts in interpretive mode. However, you can run into problems with serialization of compiled functions and scripts:
 
-```
-`$``cat test.js
-`function f() { return 3; }
- serialize(f, "f.ser");
- g = deserialize("f.ser");
- print(g());` `$``java org.mozilla.javascript.tools.shell.Main -opt -1
-test.js` 3 `$``java org.mozilla.javascript.tools.shell.Main test.js` `js: uncaught JavaScript exception: java.lang.ClassNotFoundException:
-c1``
+```sh
+$ cat test.js
+function f() { return 3; }
+serialize(f, "f.ser");
+g = deserialize("f.ser");
+print(g());
+
+$ java org.mozilla.javascript.tools.shell.Main -opt -1 test.js
+3
+
+$ java org.mozilla.javascript.tools.shell.Main test.js
+js: uncaught JavaScript exception: java.lang.ClassNotFoundException: c1
 ```
 
 The problem is that Java serialization has no built-in way to serialize Java classes themselves. (It might be possible to save the Java bytecodes in an array and then load the class upon deserialization, but at best that would eat up a lot of memory for just this feature.) One way around this is to compile the functions using the jsc tool:
 
-```
-`$``cat f.js``function f() { return 3; }``$``java -classpath js.jar
-org.mozilla.javascript.tools.jsc.Main f.js``$``cat test2.js``loadClass("f");
- serialize(f, "f.ser");
- g = deserialize("f.ser");
- print(g());``$``java -classpath 'js.jar;.'
-org.mozilla.javascript.tools.shell.Main test2.js``3`
+```sh
+$ cat f.js
+function f() { return 3; }
+
+$ java -classpath js.jar org.mozilla.javascript.tools.jsc.Main f.js
+
+$ cat test2.js
+loadClass("f");
+serialize(f, "f.ser");
+g = deserialize("f.ser");
+print(g());
+
+$ java -classpath 'js.jar;.' org.mozilla.javascript.tools.shell.Main test2.js
+3
 ```
 
 Now the function _f_ is compiled to a Java class, but that class is then made available in the classpath so serialization works. This isn't that interesting an example since compiling a function to a class and then loading it accomplishes the same as serializing an interpreted function, but it becomes more relevant if you wish to serialize JavaScript objects that have references to compiled functions.

--- a/docs/_tools/debugger.md
+++ b/docs/_tools/debugger.md
@@ -3,13 +3,11 @@ title: "Debugger"
 ---
 
 # Debugger
-
 {: .no_toc }
 
 {: .fs-6 .fw-300 }
 
 ## Table of contents
-
 {: .no_toc .text-delta }
 
 1. TOC

--- a/docs/_tools/debugger.md
+++ b/docs/_tools/debugger.md
@@ -1,12 +1,15 @@
 ---
 title: "Debugger"
 ---
+
 # Debugger
+
 {: .no_toc }
 
 {: .fs-6 .fw-300 }
 
 ## Table of contents
+
 {: .no_toc .text-delta }
 
 1. TOC
@@ -15,7 +18,7 @@ title: "Debugger"
 ---
 The Rhino JavaScript debugger is a GUI that allows debugging of interpreted JavaScript scripts run in Rhino. Note that this debugger **will not** work with JavaScript scripts run in the mozilla browser since Rhino is not the engine used in such environments.
 
-![](../assets/images/debugger-ui.png)
+![Debugger UI](../assets/images/debugger-ui.png)
 
 Current limitations:
 
@@ -25,7 +28,7 @@ Current limitations:
 
 The Mozilla Rhino JavaScript engine includes a source-level debugger for debugging JavaScript scripts. The debugger is itself a Java program which you may run as
 
-```
+```sh
 java org.mozilla.javascript.tools.debugger.Main [options] [filename.js] [script-arguments]
 ```
 

--- a/docs/_tools/javascript_compiler.md
+++ b/docs/_tools/javascript_compiler.md
@@ -3,13 +3,11 @@ title: "JavaScript compiler"
 ---
 
 # JavaScript compiler
-
 {: .no_toc }
 
 {: .fs-6 .fw-300 }
 
 ## Table of contents
-
 {: .no_toc .text-delta }
 
 1. TOC

--- a/docs/_tools/javascript_compiler.md
+++ b/docs/_tools/javascript_compiler.md
@@ -1,25 +1,29 @@
 ---
 title: "JavaScript compiler"
 ---
+
 # JavaScript compiler
+
 {: .no_toc }
 
 {: .fs-6 .fw-300 }
 
 ## Table of contents
+
 {: .no_toc .text-delta }
 
 1. TOC
 {:toc}
 
 ---
-### Overview
+
+## Overview
 
 The JavaScript compiler translates JavaScript source into Java class files. The resulting Java class files can then be loaded and executed at another time, providing a convenient method for transferring JavaScript, and for avoiding translation cost.
 
 Note that the top-level functions available to the shell (such as print) are not available to compiled scripts when they are run outside the shell.
 
-### Compiler command line
+## Compiler command line
 
 `java org.mozilla.javascript.tools.jsc.Main` [_options_] `file1.js [file2.js...]`
 
@@ -67,16 +71,20 @@ Specifies the package to generate the class into. The string _packageName_ must 
 
 Specifies the language version to compile with. The string _versionNumber_ must be one of 100, 110, 120, 130, 140, 150, 160, or 170. See [JavaScript Language Versions](../_docs/overview.md#javascript_language_versions) for more information on language versions.
 
-### Examples
+## Examples
 
-```
+```sh
 $ cat test.js
 java.lang.System.out.println("hi, mom!");
+
 $ java org.mozilla.javascript.tools.jsc.Main test.js
+
 $ ls *.class
 test.class
+
 $ java test
 hi, mom!
+
 $ java org.mozilla.javascript.tools.jsc.Main -extends java.applet.Applet
     -implements java.lang.Runnable NervousText.js
 ```

--- a/docs/_tools/shell.md
+++ b/docs/_tools/shell.md
@@ -1,12 +1,15 @@
 ---
 title: "Shell"
 ---
+
 # Shell
+
 {: .no_toc }
 
 {: .fs-6 .fw-300 }
 
 ## Table of contents
+
 {: .no_toc .text-delta }
 
 1. TOC
@@ -15,7 +18,7 @@ title: "Shell"
 ---
 The JavaScript shell provides a simple way to run scripts in batch mode or an interactive environment for exploratory programming.
 
-### Invoking the Shell
+## Invoking the Shell
 
 `java org.mozilla.javascript.tools.shell.Main [options] script-filename-or-url [script-arguments]`
 
@@ -29,7 +32,7 @@ Executes _script-source_ as a JavaScript script.
 
 Reads _script-filename-or-url_ content and execute it as a JavaScript script.
 
-#### `-opt optLevel` / `-O optLevel`
+### `-opt optLevel` / `-O optLevel`
 
 Optimizes at level _optLevel_, which must be `-1` or an integer between `0` and `9`. See [Rhino Optimization](../_docs/optimization.md) for more details.
 
@@ -45,11 +48,11 @@ Enable strict mode.
 
 Enable experimental support for continuations and set the optimization level to -1 to force interpretation mode. Starting with Rhino 1.7 this options is no longer available.
 
-#### Note
+### Note
 
 If the shell is invoked with the system property `rhino.use_java_policy_security` set to `true` and with a security manager installed, the shell restricts scripts permissions based on their URLs according to Java policy settings. This is available only if JVM implements Java2 security model.
 
-### Predefined Properties
+## Predefined Properties
 
 Scripts executing in the shell have access to some additional properties of the top-level object.
 
@@ -107,7 +110,7 @@ Execute the specified command with the given argument and options as a separate 
 
 Usage:
 
-```
+```sh
 runCommand(command)
 runCommand(command, arg1, ..., argN)
 runCommand(command, arg1, ..., argN, options)
@@ -147,15 +150,16 @@ Quit shell. The shell will also quit in interactive mode if an end-of-file chara
 
 Get or set JavaScript version number. If no argument is supplied, the current version number is returned. If an argument is supplied, it is expected to be one of `100`, `110`, `120`, `130`, `140`, `150`, `160 or 170` to indicate JavaScript version 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6 or 1.7 respectively.
 
-### Examples
+## Examples
 
-#### Invocation
+### Invocation
 
 Here the shell is invoked three times from the command line. (The system command prompt is shown as `$`.) The first invocation executes a script specified on the command line itself. The next invocation has no arguments, so the shell goes into interactive mode, reading and evaluating each line as it is typed in. Finally, the last invocation executes a script from a file and accesses arguments to the script itself.
 
-```
+```sh
 $ java org.mozilla.javascript.tools.shell.Main -e "print('hi')"
 hi
+
 $ java org.mozilla.javascript.tools.shell.Main
 js> print('hi')
 hi
@@ -168,21 +172,22 @@ js> var a = 34;
 js> f()
 34
 js> quit()
+
 $ cat echo.js
 for (i in arguments) {
   print(arguments[i])
 }
+
 $ java org.mozilla.javascript.tools.shell.Main echo.js foo bar
 foo
 bar
-$
 ```
 
-#### `spawn` and `sync`
+### `spawn` and `sync`
 
 The following example creates 2 threads via `spawn` and uses `sync` to create a synchronized version of the function `test`.
 
-```
+```js
 js> function test(x) {
   print("entry");
   java.lang.Thread.sleep(x*1000);
@@ -204,7 +209,7 @@ exit
 
 Here are a few examples of invoking `runCommand` under Linux.
 
-```
+```js
 js> runCommand('date')
 Thu Jan 23 16:49:36 CET 2003
 0
@@ -245,7 +250,7 @@ js> runCommand("echo", { args: arg_array})
 
 Examples for Windows are similar:
 
-```
+```js
 js> // Invoke shell command
 js> runCommand("cmd", "/C", "date /T")
 27.08.2005

--- a/docs/_tools/shell.md
+++ b/docs/_tools/shell.md
@@ -3,13 +3,11 @@ title: "Shell"
 ---
 
 # Shell
-
 {: .no_toc }
 
 {: .fs-6 .fw-300 }
 
 ## Table of contents
-
 {: .no_toc .text-delta }
 
 1. TOC

--- a/docs/_tutorials/embedding_tutorial.md
+++ b/docs/_tutorials/embedding_tutorial.md
@@ -1,12 +1,15 @@
 ---
 title: "Embedding Rhino"
 ---
+
 # Embedding Rhino
+
 {: .no_toc }
 
 {: .fs-6 .fw-300 }
 
 ## Table of contents
+
 {: .no_toc .text-delta }
 
 1. TOC
@@ -27,7 +30,7 @@ About the simplest embedding of Rhino possible is the [RunScript example](https:
 
 Here's an example use of RunScript from a shell command line:
 
-```
+```sh
 $ java RunScript "Math.cos(Math.PI)"
 -1
 $ java RunScript "function f(x){return x+1} f(7)"
@@ -40,7 +43,7 @@ Note that you'll have to have both the Rhino classes and the RunScript example c
 
 The code
 
-```
+```java
 Context cx = Context.enter();
 ```
 
@@ -50,7 +53,7 @@ Creates and enters a `Context`. A `Context` stores information about the executi
 
 The code
 
-```
+```java
 Scriptable scope = cx.initStandardObjects();
 ```
 
@@ -60,7 +63,7 @@ Initializes the standard objects (`Object`, `Function`, etc.) This must be done 
 
 This code is standard Java and not specific to Rhino. It just collects all the arguments and concatenates them together.
 
-```
+```java
 String s = "";
 for (int i=0; i < args.length; i++) {
     s += args[i];
@@ -71,7 +74,7 @@ for (int i=0; i < args.length; i++) {
 
 The code
 
-```
+```java
 Object result = cx.evaluateString(scope, s, "<cmd>", 1, null);
 ```
 
@@ -81,7 +84,7 @@ uses the Context `cx` to evaluate a string. Evaluation of the script looks up va
 
 The code
 
-```
+```java
 System.out.println(cx.toString(result));
 ```
 
@@ -91,7 +94,7 @@ prints the result of evaluating the script (contained in the variable _result_).
 
 The code
 
-```
+```java
 } finally {
     Context.exit();
 }
@@ -105,7 +108,7 @@ exits the Context. This removes the association between the Context and the curr
 
 No additional code in the embedding needed! The JavaScript feature called_LiveConnect_ allows JavaScript programs to interact with Java objects:
 
-```
+```sh
 $ java RunScript "java.lang.System.out.println(3)"
 3.0
 undefined
@@ -115,7 +118,7 @@ undefined
 
 Using Rhino, JavaScript objects can implement arbitrary Java interfaces. There's no Java code to write -- it's part of Rhino's LiveConnect implementation. For example, we can see how to implement java.lang.Runnable in a Rhino shell session:
 
-```
+```js
 js> obj = { run: function() { print("hi"); } }
 [object Object]
 js> obj.run()
@@ -132,14 +135,14 @@ hi
 
 The next example is [RunScript2](https://github.com/mozilla/rhino/examples/RunScript2.java). This is the same as RunScript, but with the addition of two extra lines of code:
 
-```
+```java
 Object wrappedOut = Context.javaToJS(System.out, scope);
 ScriptableObject.putProperty(scope, "out", wrappedOut);
 ```
 
 These lines add a global variable `out` that is a JavaScript reflection of the `System.out` variable:
 
-```
+```sh
 $ java RunScript2 "out.println(42)"
 42.0
 undefined
@@ -149,7 +152,7 @@ undefined
 
 After evaluating a script it's possible to query the scope for variables and functions, extracting values and calling JavaScript functions. This is illustrated in the [RunScript3](https://github.com/mozilla/rhino/examples/RunScript3.java) example. This example adds the ability to print the value of variable _x_ and the result of calling function `f`. Both _x_ and _f_ are expected to be defined by the evaluated script. For example,
 
-```
+```sh
 $ java RunScript3 "x = 7"
 x = 7
 f is undefined or not a function.
@@ -162,7 +165,7 @@ f("my args") = my arg
 
 To print out the value of _x_, we add the following code:
 
-```
+```java
 Object x = scope.get("x", scope);
 if (x == Scriptable.NOT_FOUND) {
     System.out.println("x is not defined.");
@@ -175,7 +178,7 @@ if (x == Scriptable.NOT_FOUND) {
 
 To get the function _f_, call it, and print the result, we add this code:
 
-```
+```java
 Object fObj = scope.get("f", scope);
 if (!(fObj instanceof Function)) {
     System.out.println("f is undefined or not a function.");
@@ -200,7 +203,7 @@ The [Counter example](https://github.com/mozilla/rhino/examples/Counter.java) is
 
 It's easy to try out new host object classes in the shell using its built-in `defineClass` function. We'll see how to add it to RunScript later. (Note that because the `java -jar` option preempts the rest of the classpath, we can't use that and access the `Counter` class.)
 
-```
+```sh
 $ java -cp "js.jar;examples" org.mozilla.javascript.tools.shell.Main
 js> defineClass("Counter")
 js> c = new Counter(7)
@@ -220,13 +223,13 @@ js> c.count
 
 The zero-argument constructor is used by Rhino runtime to create instances. For the counter example, no initialization work is needed, so the implementation is empty.
 
-```
+```java
 public Counter () { }
 ```
 
 The method `jsConstructor` defines the JavaScript constructor that was called with the expression `new Counter(7)` in the JavaScript code above.
 
-```
+```java
 public void jsConstructor(int a) { count
 = a; }
 ```
@@ -235,7 +238,7 @@ public void jsConstructor(int a) { count
 
 The class name is defined by the `getClassName` method. This is used to determine the name of the constructor.
 
-```
+```java
 public String getClassName() { return "Counter";
 }
 ```
@@ -244,7 +247,7 @@ public String getClassName() { return "Counter";
 
 Dynamic properties are defined by methods beginning with `jsGet_` or `jsSet_`. The method `jsGet_count` defines the_count_ property.
 
-```
+```java
 public int jsGet_count() { return count++;
 }
 ```
@@ -255,7 +258,7 @@ The expression `c.count` in the JavaScript code above results in a call to this 
 
 Methods can be defined using the `jsFunction_ prefix`. Here we define `resetCount` for JavaScript.
 
-```
+```java
 public void jsFunction_resetCount() { count
 = 0; }
 ```
@@ -266,20 +269,20 @@ The call `c.resetCount()` above calls this method.
 
 Now take a look at the [RunScript4 example](https://github.com/mozilla/rhino/examples/RunScript4.java). It's the same as RunScript except for two additions. The method `ScriptableObject.defineClass` uses a Java class to define the Counter "class" in the top-level scope:
 
-```
+```java
 ScriptableObject.defineClass(scope, Counter.class);
 ```
 
 Now we can reference the `Counter` object from our script:
 
-```
+```sh
 $ java RunScript4 "c = new Counter(3); c.count;
 c.count;"
 ```
 
 It also creates a new instance of the `Counter` object from within our Java code, constructing it with the value 7, and assigning it to the top-level variable `myCounter`:
 
-```
+```java
 Object[] arg = { new Integer(7) };
 Scriptable myCounter = cx.newObject(scope, "Counter", arg);
 scope.put("myCounter", scope, myCounter);
@@ -287,7 +290,7 @@ scope.put("myCounter", scope, myCounter);
 
 Now we can reference the `myCounter` object from our script:
 
-```
+```sh
 $ java RunScript3 'RunScript4 'myCounter.count; myCounter.count'
 8
 ```

--- a/docs/_tutorials/embedding_tutorial.md
+++ b/docs/_tutorials/embedding_tutorial.md
@@ -3,13 +3,11 @@ title: "Embedding Rhino"
 ---
 
 # Embedding Rhino
-
 {: .no_toc }
 
 {: .fs-6 .fw-300 }
 
 ## Table of contents
-
 {: .no_toc .text-delta }
 
 1. TOC

--- a/docs/_tutorials/embedding_tutorial.md
+++ b/docs/_tutorials/embedding_tutorial.md
@@ -20,8 +20,6 @@ This tutorial leads you through the steps from a simple embedding to more custom
 
 The examples live in the `rhino/examples` directory in the distribution and in `mozilla/js/rhino/examples` in cvs. This document will link to them using [lxr](https://lxr.mozilla.org/).
 
-In this document, JavaScript code will be in `green`, Java code will be in `green,` and shell logs will be in `purple`.
-
 ## RunScript: A simple embedding
 
 About the simplest embedding of Rhino possible is the [RunScript example](https://github.com/mozilla/rhino/examples/RunScript.java). All it does it read a script from the command line, execute it, and print a result.

--- a/docs/_tutorials/scripting_java.md
+++ b/docs/_tutorials/scripting_java.md
@@ -1,12 +1,15 @@
 ---
 title: "Scripting Java"
 ---
+
 # Scripting Java
+
 {: .no_toc }
 
 {: .fs-6 .fw-300 }
 
 ## Table of contents
+
 {: .no_toc .text-delta }
 
 1. TOC
@@ -17,34 +20,34 @@ This article shows how to use Rhino to reach beyond JavaScript into Java. Script
 
 Note that the ECMA standard doesn't cover communication with Java (or with any external object system for that matter). All the functionality covered in this chapter should thus be considered an extension.
 
-### Accessing Java Packages and Classes
+## Accessing Java Packages and Classes
 
 Every piece of Java code is part of a class. Every Java class is part of a package. In JavaScript, however, scripts exist outside of any package hierarchy. How then, do we access classes in Java packages?
 
 Rhino defines a top-level variable named `Packages`. The properties of the `Packages` variable are all the top-level Java packages, such as `java` and `com`. For example, we can access the value of the`java`package:
 
-```
+```js
 js> Packages.java
 [JavaPackage java]
 ```
 
 As a handy shortcut, Rhino defines a top-level variable `java` that is equivalent to `Packages.java`. So the previous example could be even shorter:
 
-```
+```js
 js> java
 [JavaPackage java]
 ```
 
 We can access Java classes simply by stepping down the package hierarchy:
 
-```
+```js
 js> java.io.File
 [JavaClass java.io.File]
 ```
 
 If your scripts access a lot of different Java classes, it can get awkward to use the full package name of the class every time. Rhino provides a top-level function `importPackage` that serves the same purpose as Java's `import` declaration. For example, we could import all of the classes in the `java.io` package and access class `java.io.File` using just the name `File`:
 
-```
+```js
 js> importPackage(java.io)
 js> File
 [JavaClass java.io.File]
@@ -56,18 +59,18 @@ It's important to note that Java imports `java.lang.*` implicitly, while Rhino d
 
 One thing to be careful of is Rhino's handling of errors in specifying Java package or class names. If `java.MyClass` is accessed, Rhino attempts to load a class named `java.MyClass`. If that load fails, it assumes that `java.MyClass` is a package name, and no error is reported:
 
-```
+```js
 js> java.MyClass
 [JavaPackage java.MyClass]
 ```
 
 Only if you attempt to use this object as a class will an error be reported.
 
-#### External Packages and Classes
+### External Packages and Classes
 
 External packages and classes can also be used as in Rhino. Make sure your `.jar` or `.class` file is on you classpath then you may import them into your JavaScript application. These packages are likely not in the `java` package, so you'll need to prefix the package name with "`Packages.`" For example, to import the `org.mozilla.javascript` package you could use `importPackage()` as follows:
 
-```
+```sh
 $ java org.mozilla.javascript.tools.shell.Main
 js> importPackage(Packages.org.mozilla.javascript);
 js> Context.currentContext;
@@ -76,7 +79,7 @@ org.mozilla.javascript.Context@bb6ab6
 
 Occasionally, you will see examples that use the fully qualified name of the package instead of importing using the `importPackage()` method. This is also acceptable, it just takes more typing. Using a fully qualified name, the above example would look as follows:
 
-```
+```sh
 $ java org.mozilla.javascript.tools.shell.Main
 js> jsPackage = Packages.org.mozilla.javascript;
 [JavaPackage org.mozilla.javascript]
@@ -86,25 +89,25 @@ org.mozilla.javascript.Context@bb6ab6
 
 Alternatively, if you want to import just one class from a package you can do so using the `importClass()` method. The above examples could be expressed as follows:
 
-```
+```sh
 $ java org.mozilla.javascript.tools.shell.Main
 js> importClass(Packages.org.mozilla.javascript.Context);
 js>  Context.currentContext;
 org.mozilla.javascript.Context@bb6ab6
 ```
 
-### Working with Java
+## Working with Java
 
 Now that we can access Java classes, the next logical step is to create an object. This works just as in Java, with the use of the `new` operator:
 
-```
+```js
 js> new java.util.Date()
 Thu Jan 24 16:18:17 EST 2002
 ```
 
 If we store the new object in a JavaScript variable, we can then call methods on it:
 
-```
+```js
 js> f = new java.io.File("test.txt")
 test.txt
 js> f.exists()
@@ -115,7 +118,7 @@ test.txt
 
 Static methods and fields can be accessed from the class object itself:
 
-```
+```js
 js> java.lang.Math.PI
 3.141592653589793
 js> java.lang.Math.cos(0)
@@ -124,7 +127,7 @@ js> java.lang.Math.cos(0)
 
 In JavaScript, unlike Java, the method by itself is an object and can be evaluated as well as being called. If we just view the method object by itself we can see the various overloaded forms of the method:
 
-```
+```js
 js> f.listFiles
 function listFiles() {/*
 java.io.File[] listFiles()
@@ -137,7 +140,7 @@ This output shows that the `File` class defines three overloaded methods `listFi
 
 Another useful feature for exploratory programming is the ability to see all the methods and fields defined for an object. Using the JavaScript `for..in` construct, we can print out all these values:
 
-```
+```js
 js> for (i in f) { print(i) }
 exists
 parentFile
@@ -151,20 +154,20 @@ Note that not only the methods of the `File` class are listed, but also the meth
 
 Rhino provides another convenience by allowing properties of JavaBeans to be accessed directly by their property names. A JavaBean property `foo` is defined by the methods `getFoo` and `setFoo`. Additionally, a boolean property of the same name can be defined by an `isFoo` method. For example, the following code actually calls the `File` object's `getName` and `isDirectory` methods.
 
-```
+```js
 js> f.name
 test.txt
 js> f.directory
 false
 ```
 
-### Calling Overloaded Methods
+## Calling Overloaded Methods
 
 The process of choosing a method to call based upon the types of the arguments is called _overload resolution_. In Java, overload resolution is performed at compile time, while in Rhino it occurs at runtime. This difference is inevitable given JavaScript's use of dynamic typing as was discussed in Chapter 2: since the type of a variable is not known until runtime, only then can overload resolution occur.
 
 As an example, consider the following Java class that defines a number of overloaded methods and calls them.
 
-```
+```java
 public class Overload {
     public String f(Object o) { return "f(Object)"; }
     public String f(String s) { return "f(String)"; }
@@ -184,7 +187,7 @@ public class Overload {
 
 When we compile and execute the program, it produces the output
 
-```
+```text
 f(Object)
 f(Object)
 f(Object)
@@ -192,7 +195,7 @@ f(Object)
 
 However, if we write a similar script
 
-```
+```js
 var o = new Packages.Overload();
 var a = [ 3, "hi", Packages.Overload ];
 for (var i = 0; i != a.length; ++i)
@@ -201,7 +204,7 @@ for (var i = 0; i != a.length; ++i)
 
 and execute it, we get the output
 
-```
+```text
 f(int)
 f(String)
 f(Object)
@@ -213,7 +216,7 @@ Although this has the benefit of selecting a method that may be a better match f
 
 Because overload resolution occurs at runtime, it can fail at runtime. For example, if we call `Overload`'s method `g` with two integers we get an error because neither form of the method is closer to the argument types than the other:
 
-```
+```js
 js> o.g(3,4)
 js:"<stdin>", line 2: The choice of Java method Overload.g
 matching JavaScript argument types (number,number) is ambiguous;
@@ -230,7 +233,7 @@ Now that we can access Java classes, create Java objects, and access fields, met
 
 To address this need, Rhino provides the ability to create new Java objects that implement interfaces. First we must define a JavaScript object with function properties whose names match the methods required by the Java interface. To implement a `Runnable`, we need only define a single method `run` with no parameters. If you remember from Chapter 3, it is possible to define a JavaScript object with the `{propertyName: value}` notation. We can use that syntax here in combination with a function expression to define a JavaScript object with a `run` method:
 
-```
+```js
 js> obj = { run: function () { print("\nrunning"); } }
 [object Object]
 js> obj.run()
@@ -240,14 +243,14 @@ running
 
 Now we can create an object implementing the `Runnable` interface by constructing a `Runnable`:
 
-```
+```js
 js> r = new java.lang.Runnable(obj);
 [object JavaObject]
 ```
 
 In Java it is not possible to use the `new` operator on an interface because there is no implementation available. Here Rhino gets the implementation from the JavaScript object `obj`. Now that we have an object implementing `Runnable`, we can create a `Thread` and run it. The function we defined for `run`will be called on a new thread.
 
-```
+```js
 js> t = new java.lang.Thread(r)
 Thread[Thread-2,5,main]
 js> t.start()
@@ -266,7 +269,7 @@ In the previous section we created Java adapters using the `new` operator with J
 
 The syntax of the `JavaAdapter` constructor is:
 
-```
+```java
 new JavaAdapter(javaIntfOrClass, [javaIntf, ..., javaIntf,] javascriptObject)
 ```
 
@@ -280,7 +283,7 @@ Often we need to implement an interface with only one method, like in the previo
 
 Here is the simplified `Runnable` example:
 
-```
+```js
 js> t = java.lang.Thread(function () { print("\nrunning"); });
 Thread[Thread-0,5,main]
 js> t.start()
@@ -290,12 +293,12 @@ running
 
 Rhino also allows use of JavaScript functions as implementations of Java interfaces with more than one method if all the methods have the same signature. When calling the function, Rhino passes the method's name as the additional argument. Function can use it to distinguish on behalf of which method it was called:
 
-```
+```js
 js> var frame = new Packages.javax.swing.JFrame();
 js> frame.addWindowListener(function(event, methodName) {
-	if (methodName == "windowClosing") {
+        if (methodName == "windowClosing") {
             print("Calling System.exit()..."); java.lang.System.exit(0);
-	}
+        }
     });
 js> frame.setSize(100, 100);
 js> frame.visible = true;
@@ -307,21 +310,21 @@ js> Calling System.exit()...
 
 Rhino provides no special syntax for creating Java arrays. You must use the `java.lang.reflect.Array` class for this purpose. To create an array of five Java strings you would make the following call:
 
-```
+```js
 js> a = java.lang.reflect.Array.newInstance(java.lang.String, 5);
 [Ljava.lang.String;@7ffe01
 ```
 
 To create an array of primitive types, we must use the special TYPE field defined in the associated object class in the `java.lang` package. For example, to create an array of bytes, we must use the special field `java.lang.Byte.TYPE`:
 
-```
+```js
 js> a = java.lang.reflect.Array.newInstance(java.lang.Character.TYPE, 2);
 [C@7a84e4
 ```
 
 The resulting value can then be used anywhere a Java array of that type is allowed.
 
-```
+```js
 js> a[0] = 104
 104
 js> a[1] = 105
@@ -334,7 +337,7 @@ hi
 
 It's important to keep in mind that Java strings and JavaScript strings are **not** the same. Java strings are instances of the type `java.lang.String` and have all the methods defined by that class. JavaScript strings have methods defined by `String.prototype`. The most common stumbling block is `length`, which is a method of Java strings and a dynamic property of JavaScript strings:
 
-```
+```js
 js> javaString = new java.lang.String("Java")
 Java
 js> jsString = "JavaScript"
@@ -349,7 +352,7 @@ Rhino provides some help in reducing the differences between the two types. Firs
 
 Rhino also makes the JavaScript methods available to Java strings if the java.lang.String class doesn't already define them. For example:
 
-```
+```js
 js> javaString.match(/a.*/)
 ava
 ```
@@ -358,7 +361,7 @@ ava
 
 `JavaImporter` is a new global constructor that allows to omit explicit package names when scripting Java:
 
-```
+```js
 var SwingGui = JavaImporter(Packages.javax.swing,
                             Packages.javax.swing.event,
                             Packages.javax.swing.border,
@@ -389,7 +392,7 @@ Exceptions thrown by Java methods can be caught by JavaScript code using [try...
 
 The `instanceof` operator can be used to query the type of an exception:
 
-```
+```js
 try {
     java.lang.Class.forName("NonExistingClass");
 } catch (e) {
@@ -401,7 +404,7 @@ try {
 
 Rhino also supports an extension to the try...catch statement that allows to define conditional catching of exceptions:
 
-```
+```js
 function classForName(name) {
     try {
         return java.lang.Class.forName(name);

--- a/docs/_tutorials/scripting_java.md
+++ b/docs/_tutorials/scripting_java.md
@@ -225,7 +225,7 @@ class java.lang.String g(int,java.lang.String)
 
 See [Java Method Overloading and LiveConnect 3](https://web.archive.org/web/20110623074154/http://www.mozilla.org/js/liveconnect/lc3_method_overloading.html) for a more precise definition of overloading semantics.
 
-### Implementing Java Interfaces
+## Implementing Java Interfaces
 
 Now that we can access Java classes, create Java objects, and access fields, methods, and properties of those objects, we have a great deal of power at our fingertips. However, there are a few instances where that is not enough: many APIs in Java work by providing interfaces that clients must implement. One example of this is the `Thread` class: its constructor takes a `Runnable` that contains a single method `run` that will be called when the new thread is started.
 
@@ -261,7 +261,7 @@ The final `js` prompt and the output from the new thread may appear in either or
 
 Behind the scenes, Rhino generates the bytecode for a new Java class that implements `Runnable` and forwards all calls to its `run` method over to an associated JavaScript object. The object that implements this class is called a _Java adapter_. Because the forwarding to JavaScript occurs at runtime, it is possible to delay defining the methods implementing an interface until they are called. While omitting a required method is bad practice for programming in the large, it's useful for small scripts and for exploratory programming.
 
-### The JavaAdapter Constructor
+## The JavaAdapter Constructor
 
 In the previous section we created Java adapters using the `new` operator with Java interfaces. This approach has its limitations: it's not possible to implement multiple interfaces, nor can we extend non-abstract classes. For these reasons there is a `JavaAdapter` constructor.
 

--- a/docs/_tutorials/scripting_java.md
+++ b/docs/_tutorials/scripting_java.md
@@ -3,13 +3,11 @@ title: "Scripting Java"
 ---
 
 # Scripting Java
-
 {: .no_toc }
 
 {: .fs-6 .fw-300 }
 
 ## Table of contents
-
 {: .no_toc .text-delta }
 
 1. TOC

--- a/docs/_tutorials/scripting_java.md
+++ b/docs/_tutorials/scripting_java.md
@@ -275,7 +275,7 @@ Here `javaIntfOrClass` is an interface to implement or a class to extend and `ja
 
 In practice there's little need to call the `JavaAdapter` constructor directly. Most of the time the previous syntaxes using the `new` operator will be sufficient.
 
-### JavaScript Functions as Java Interfaces
+## JavaScript Functions as Java Interfaces
 
 Often we need to implement an interface with only one method, like in the previous `Runnable` example or when providing various event listener implementations. To facilitate this Rhino allows to pass JavaScript function when such interface is expected. The function is called as the implementation of interface method.
 
@@ -304,7 +304,7 @@ true
 js> Calling System.exit()...
 ```
 
-### Creating Java Arrays
+## Creating Java Arrays
 
 Rhino provides no special syntax for creating Java arrays. You must use the `java.lang.reflect.Array` class for this purpose. To create an array of five Java strings you would make the following call:
 
@@ -331,7 +331,7 @@ js> new java.lang.String(a)
 hi
 ```
 
-### Java Strings and JavaScript Strings
+## Java Strings and JavaScript Strings
 
 It's important to keep in mind that Java strings and JavaScript strings are **not** the same. Java strings are instances of the type `java.lang.String` and have all the methods defined by that class. JavaScript strings have methods defined by `String.prototype`. The most common stumbling block is `length`, which is a method of Java strings and a dynamic property of JavaScript strings:
 
@@ -355,7 +355,7 @@ js> javaString.match(/a.*/)
 ava
 ```
 
-### JavaImporter Constructor
+## JavaImporter Constructor
 
 `JavaImporter` is a new global constructor that allows to omit explicit package names when scripting Java:
 
@@ -381,7 +381,7 @@ Previously such functionality was available only to embeddings that used [`org.m
 
 See [Bugzilla 245882](https://bugzilla.mozilla.org/show_bug.cgi?id=245882) for details.
 
-### Java Exceptions
+## Java Exceptions
 
 Exceptions thrown by Java methods can be caught by JavaScript code using [try...catch statement](https://developer.mozilla.org/en-US/docs/JavaScript/Guide/Exception_Handling_Statements/try...catch_Statement). Rhino wraps Java exceptions into error objects with the following properties:
 

--- a/docs/community.md
+++ b/docs/community.md
@@ -3,11 +3,13 @@ title: Community
 nav_order: 3
 ---
 # {{ page.title }}
+
 {: .no_toc }
 
 {: .fs-6 .fw-300 }
 
 ## Table of contents
+
 {: .no_toc .text-delta }
 
 1. TOC
@@ -16,7 +18,7 @@ nav_order: 3
 ---
 Have a question that you can't find answer to in the [Rhino documentation](./_docs/documentation.md)? Here are some additional resources for help:
 
-#### Mailing List
+## Mailing List
 
 Rhino discussions happen on the [mozilla-rhino](https://groups.google.com/group/mozilla-rhino) group on Google Groups.
 
@@ -24,7 +26,7 @@ There is a much older group, [mozilla.dev.tech.js-engine.rhino](news://news.mozi
 
 The [mozilla.dev.tech.js-engine](news://news.mozilla.org/mozilla.dev.tech.js-engine) newsgroup answers questions about the C implementation of JavaScript, and was also used for answering questions about Rhino until September 27, 2007. To view archived messages _earlier than_ September 27, 2007, try [Google group for the earlier newsgroup](https://groups.google.com/group/mozilla.dev.tech.js-engine/topics).
 
-#### Bug System
+Bug System
 
 The best way to enter Rhino bugs to enter an [issue in GitHub.](https://github.com/mozilla/rhino/issues)
 

--- a/docs/community.md
+++ b/docs/community.md
@@ -3,13 +3,11 @@ title: Community
 nav_order: 3
 ---
 # {{ page.title }}
-
 {: .no_toc }
 
 {: .fs-6 .fw-300 }
 
 ## Table of contents
-
 {: .no_toc .text-delta }
 
 1. TOC
@@ -26,7 +24,7 @@ There is a much older group, [mozilla.dev.tech.js-engine.rhino](news://news.mozi
 
 The [mozilla.dev.tech.js-engine](news://news.mozilla.org/mozilla.dev.tech.js-engine) newsgroup answers questions about the C implementation of JavaScript, and was also used for answering questions about Rhino until September 27, 2007. To view archived messages _earlier than_ September 27, 2007, try [Google group for the earlier newsgroup](https://groups.google.com/group/mozilla.dev.tech.js-engine/topics).
 
-Bug System
+## Bug System
 
 The best way to enter Rhino bugs to enter an [issue in GitHub.](https://github.com/mozilla/rhino/issues)
 

--- a/docs/history.md
+++ b/docs/history.md
@@ -3,11 +3,13 @@ title: History
 nav_order: 4
 ---
 # {{ page.title }}
+
 {: .no_toc }
 
 {: .fs-6 .fw-300 }
 
 ## Table of contents
+
 {: .no_toc .text-delta }
 
 1. TOC

--- a/docs/history.md
+++ b/docs/history.md
@@ -3,13 +3,11 @@ title: History
 nav_order: 4
 ---
 # {{ page.title }}
-
 {: .no_toc }
 
 {: .fs-6 .fw-300 }
 
 ## Table of contents
-
 {: .no_toc .text-delta }
 
 1. TOC

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,14 +9,14 @@ nav_order: 1
 
 **Rhino** is an open-source implementation of [JavaScript](https://developer.mozilla.org/en-US/docs/Web/JavaScript) written entirely in Java. It is typically embedded into Java applications to provide scripting to end users. It is embedded in J2SE 6 as the default Java scripting engine.
 
-#### Rhino downloads
+## Rhino downloads
 
 How to [get source and binaries](./_docs/releases/index.md).
 
-#### Rhino documentation
+## Rhino documentation
 
 [Information on Rhino](./_docs/documentation.md) for script writers and embedders.
 
-#### Rhino help
+## Rhino help
 
 [Some resources](community.md) if you get stuck.


### PR DESCRIPTION
- add language specifier to code blocks to enable syntax highlighting
- add line breaks to code blocks
- end files with a single newline character
- increment heading levels by one level at a time
- add alternate text (alt text) to images
- surround headings by blank lines
- fix inverted links

https://github.com/mozilla/rhino/issues/954